### PR TITLE
Post-Release 0.3.0

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,39 @@
+# Simple: publish to PyPI when a GitHub Release is published AND the tag starts with 'v'.
+# Assumes: releases are cut from main; no prereleases; PyPI Trusted Publishing + attestations.
+
+name: Upload Package to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write   # required for PyPI Trusted Publishing (no API token)
+
+jobs:
+  deploy:
+    # Only run if the release tag starts with 'v' (e.g., v1.2.3)
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish to PyPI (OIDC + attestations)
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          attestations: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v0.4.0 (Upcoming)
 
+## New Features
+- Added auto-publish.yml GitHub Action to automatically publish new versions to PyPI upon GitHub Release.
+
 # v0.3.0 (September 17, 2025)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## New Features
 - Added auto-publish.yml GitHub Action to automatically publish new versions to PyPI upon GitHub Release.
 
-# v0.3.0 (September 17, 2025)
+# v0.3.1 (September 19, 2025)
 
 ### New Features
 - Added `ViralVector` and `ViralVectorInjection` classes to hold metadata about viral vectors used for gene delivery [PR #14](https://github.com/catalystneuro/ndx-ophys-devices/pull/14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# v0.3.0 (Upcoming)
+# v0.4.0 (Upcoming)
+
+# v0.3.0 (September 17, 2025)
 
 ### New Features
 - Added `ViralVector` and `ViralVectorInjection` classes to hold metadata about viral vectors used for gene delivery [PR #14](https://github.com/catalystneuro/ndx-ophys-devices/pull/14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ndx-ophys-devices"
-version = "0.2.0"
+version = "0.4.0"
 authors = [
     { name="Alessandra Trapani", email="alessandra.trapani@catalystneuro.com" },
+    { name="Paul Adkisson-Floro", email="paul.adkisson@catalystneuro.com" },
 ]
 description = "This is an NWB extension for storing metadata of devices used in optical experimental setup (microscopy, fiber photometry, optogenetic stimulation etc.)"
 readme = "README.md"

--- a/spec/ndx-ophys-devices.namespace.yaml
+++ b/spec/ndx-ophys-devices.namespace.yaml
@@ -13,4 +13,4 @@ namespaces:
         - Device
         - DeviceModel
       - source: ndx-ophys-devices.extensions.yaml
-    version: 0.3.1
+    version: 0.4.0


### PR DESCRIPTION
This PR updates the pyproject.toml and changelog post release. It also adds the auto-publish workflow that we use elsewhere in the ecosystem for more convenient PyPI publishing. 

This PR should not be merged until after #21 is merged and the GitHub release is made. 

UPDATE Sept. 19: Now that #21 is merged and the GitHub release has been made, this PR should be ready to go. I also took the liberty to update the version in the namespace yaml to try to avoid the mistake that I made with 0.3.0 in the future. 